### PR TITLE
Fix Google calendar initialization

### DIFF
--- a/src/services/GoogleCalendarService.js
+++ b/src/services/GoogleCalendarService.js
@@ -7,19 +7,25 @@ class GoogleCalendarService {
   static gapi = null;
 
   static async initClient() {
-    if (window.gapi) {
-      this.gapi = window.gapi;
-      await this.gapi.load('client:auth2', async () => {
-        await this.gapi.client.init({
-          apiKey: API_KEY,
-          clientId: CLIENT_ID,
-          discoveryDocs: [DISCOVERY_DOC],
-          scope: SCOPES
-        });
-      });
-    } else {
+    if (!window.gapi) {
       throw new Error('Google API not loaded');
     }
+
+    this.gapi = window.gapi;
+
+    await new Promise((resolve, reject) => {
+      this.gapi.load('client:auth2', () => {
+        this.gapi.client
+          .init({
+            apiKey: API_KEY,
+            clientId: CLIENT_ID,
+            discoveryDocs: [DISCOVERY_DOC],
+            scope: SCOPES,
+          })
+          .then(resolve)
+          .catch(reject);
+      });
+    });
   }
 
   static async handleAuthClick() {


### PR DESCRIPTION
## Summary
- fix GoogleCalendarService.initClient to resolve after API client load

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680e35a4a0832baa9d28742eace898